### PR TITLE
Add École Française d'Extrême-Orient (EFEO)

### DIFF
--- a/lib/domains/net/efeo.txt
+++ b/lib/domains/net/efeo.txt
@@ -1,0 +1,2 @@
+École française d'Extrême-Orient
+French School of the Far East


### PR DESCRIPTION
The French School of the Far East (École Française d'Extrême-Orient in French, abbreviated EFEO) is an associated college of Paris Sciences et Lettres University (PSL University).